### PR TITLE
Fix ASAR compatibility for real-world archives and archive-to-archive rebuilds

### DIFF
--- a/asar/asar.py
+++ b/asar/asar.py
@@ -107,16 +107,24 @@ class AsarArchive:
             node = self._search_node_from_path(path_in)
             node.set_link(path.resolve().relative_to(src))
             if node.link.parts[0] == "..":
-                raise ValueError(f'${path_in}: file "{node.link}" links out of the package')
+                raise ValueError(
+                    f'${path_in}: file "{node.link}" links out of the package'
+                )
         elif path.is_dir():
             node = self._search_node_from_path(path_in)
             node.set_dir(unpacked=unpack and fnmatch.fnmatch(path.name, unpack))
             for child in path.iterdir():
                 self._pack(child, src, unpack)
         else:
-            self.pack_file(path_in, path, should_unpack=unpack and fnmatch.fnmatch(path.name, unpack))
+            self.pack_file(
+                path_in,
+                path,
+                should_unpack=unpack and fnmatch.fnmatch(path.name, unpack),
+            )
 
-    def pack_stream(self, path_in: Path, file_reader: BinaryIO, should_unpack: bool = False):
+    def pack_stream(
+        self, path_in: Path, file_reader: BinaryIO, should_unpack: bool = False
+    ):
         """
         Add one file stream to the asar archive.
         :param path_in: the path in asar archive.
@@ -225,11 +233,16 @@ class AsarArchive:
                     node.file_path = self.asar_unpacked / node.path
                 else:
                     node.offset = int(child["offset"])
-                    node.file_reader = LimitedReader(self._asar_io, self._offset + node.offset, node.size)
+                    node.file_reader = LimitedReader(
+                        self._asar_io, self._offset + node.offset, node.size
+                    )
 
     def _write_to_asar(self):
         header_json = json.dumps(
-            self._header.to_dict(), sort_keys=True, separators=(",", ":"), ensure_ascii=False
+            self._header.to_dict(),
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
         )
         header_json = header_json.encode("utf-8")
         data_size = 4
@@ -238,7 +251,9 @@ class AsarArchive:
         header_object_size = aligned_size + data_size
         header_size = header_object_size + data_size
         self._asar_io.write(
-            struct.pack("<4I", data_size, header_size, header_object_size, header_string_size)
+            struct.pack(
+                "<4I", data_size, header_size, header_object_size, header_string_size
+            )
         )
         self._asar_io.write(header_json)
         self._asar_io.write(b"\0" * (aligned_size - header_string_size))

--- a/asar/asar.py
+++ b/asar/asar.py
@@ -3,6 +3,7 @@ Asar is a simple extensive archive format for Electron Archive, it works like ta
 together without compression, while having random access support.
 """
 
+import io
 import fnmatch
 import json
 import shutil
@@ -72,13 +73,20 @@ class AsarArchive:
 
     def pack_other_asar(self, other: "AsarArchive"):
         for meta in other.metas:
-            node = self._search_node_from_path(meta.path)
-            node.set_from_other(meta)
             if meta.type == Type.DIRECTORY:
+                node = self._search_node_from_path(meta.path)
+                node.set_dir(meta.unpacked)
                 continue
-            if meta.type == Type.FILE and not meta.unpacked:
-                node.offset = self._offset
-                self._offset += node.size
+            if meta.type == Type.LINK:
+                node = self._search_node_from_path(meta.path)
+                node.set_link(meta.link)
+                continue
+            if meta.type != Type.FILE:
+                continue
+            data = other.read(meta.path)
+            self.pack_stream(meta.path, io.BytesIO(data), should_unpack=meta.unpacked)
+            node = self._search_node_from_path(meta.path)
+            node.executable = meta.executable
 
     def pack(self, src: Path, unpack: str = None):
         """

--- a/asar/asar.py
+++ b/asar/asar.py
@@ -211,7 +211,7 @@ class AsarArchive:
             else:
                 node.unpacked = "unpacked" in child and bool(child["unpacked"])
                 node.type = Type.FILE
-                node.integrity = child["integrity"]
+                node.integrity = child.get("integrity")
                 node.size = child["size"]
                 if node.unpacked:
                     node.file_path = self.asar_unpacked / node.path

--- a/asar/asar.py
+++ b/asar/asar.py
@@ -75,7 +75,10 @@ class AsarArchive:
         for meta in other.metas:
             if meta.type == Type.DIRECTORY:
                 node = self._search_node_from_path(meta.path)
-                node.set_dir(meta.unpacked)
+                if node.type == Type.DIRECTORY and node.files is not None:
+                    node.unpacked = meta.unpacked
+                else:
+                    node.set_dir(meta.unpacked)
                 continue
             if meta.type == Type.LINK:
                 node = self._search_node_from_path(meta.path)
@@ -232,6 +235,13 @@ class AsarArchive:
                     node.file_reader = LimitedReader(self._asar_io, self._offset + node.offset, node.size)
 
     def _write_to_asar(self):
+        current_offset = 0
+        for metadata in self.metas:
+            if metadata.type != Type.FILE or metadata.unpacked:
+                continue
+            metadata.offset = current_offset
+            current_offset += metadata.size
+
         header_json = json.dumps(
             self._header.to_dict(),
             sort_keys=True,

--- a/asar/asar.py
+++ b/asar/asar.py
@@ -107,9 +107,7 @@ class AsarArchive:
             node = self._search_node_from_path(path_in)
             node.set_link(path.resolve().relative_to(src))
             if node.link.parts[0] == "..":
-                raise ValueError(
-                    f'${path_in}: file "{node.link}" links out of the package'
-                )
+                raise ValueError(f'${path_in}: file "{node.link}" links out of the package')
         elif path.is_dir():
             node = self._search_node_from_path(path_in)
             node.set_dir(unpacked=unpack and fnmatch.fnmatch(path.name, unpack))
@@ -122,9 +120,7 @@ class AsarArchive:
                 should_unpack=unpack and fnmatch.fnmatch(path.name, unpack),
             )
 
-    def pack_stream(
-        self, path_in: Path, file_reader: BinaryIO, should_unpack: bool = False
-    ):
+    def pack_stream(self, path_in: Path, file_reader: BinaryIO, should_unpack: bool = False):
         """
         Add one file stream to the asar archive.
         :param path_in: the path in asar archive.
@@ -233,9 +229,7 @@ class AsarArchive:
                     node.file_path = self.asar_unpacked / node.path
                 else:
                     node.offset = int(child["offset"])
-                    node.file_reader = LimitedReader(
-                        self._asar_io, self._offset + node.offset, node.size
-                    )
+                    node.file_reader = LimitedReader(self._asar_io, self._offset + node.offset, node.size)
 
     def _write_to_asar(self):
         header_json = json.dumps(
@@ -251,9 +245,7 @@ class AsarArchive:
         header_object_size = aligned_size + data_size
         header_size = header_object_size + data_size
         self._asar_io.write(
-            struct.pack(
-                "<4I", data_size, header_size, header_object_size, header_string_size
-            )
+            struct.pack("<4I", data_size, header_size, header_object_size, header_string_size)
         )
         self._asar_io.write(header_json)
         self._asar_io.write(b"\0" * (aligned_size - header_string_size))

--- a/asar/limited_reader.py
+++ b/asar/limited_reader.py
@@ -37,7 +37,7 @@ class LimitedReader:
             offset = end_offset + offset
         else:
             raise ValueError("invalid whence value")
-        if not (self._offset <= offset < end_offset):
+        if not (self._offset <= offset <= end_offset):
             raise ValueError("seek position is out of bounds")
         self._remaining = end_offset - offset
-        return self._reader.seek(offset, whence)
+        return self._reader.seek(offset, io.SEEK_SET)

--- a/asar/metadata.py
+++ b/asar/metadata.py
@@ -70,6 +70,7 @@ class Metadata:
         self.size = stat.st_size
         self.integrity = get_file_integrity(file_path)
         self.file_path = file_path
+        self.file_reader = None
         self.executable = os.name != "nt" and (stat.st_mode & 0o100)
 
     def set_stream(self, file_reader: Union[BinaryIO, LimitedReader], unpacked: bool):
@@ -81,6 +82,8 @@ class Metadata:
         self.unpacked = unpacked
         self.type = Type.FILE
         self.integrity, self.size = get_reader_integrity(file_reader)
+        file_reader.seek(0)
+        self.file_path = None
         self.file_reader = file_reader
 
     def set_from_other(self, other: "Metadata"):

--- a/tests/test_asar.py
+++ b/tests/test_asar.py
@@ -15,7 +15,9 @@ def _cmp_dir(d1: Path, d2: Path):
     assert len(d1_files) == len(d2_files), f"dir {d1} and {d2} is different"
     for f1, f2 in zip(d1_files, d2_files):
         if f1.is_symlink() and f2.is_symlink():
-            return f1.resolve().relative_to(d1.resolve()) == f2.resolve().relative_to(d2.resolve())
+            return f1.resolve().relative_to(d1.resolve()) == f2.resolve().relative_to(
+                d2.resolve()
+            )
         if f1.is_dir() and f2.is_dir():
             return f1.name == f2.name
         if f1.is_file() and f2.is_file():
@@ -55,7 +57,10 @@ def test_list_and_read_asar():
 
 def test_pack_other_asar():
     new_asar = Path("./tests/testdata.new.asar")
-    with AsarArchive(asar, mode="r") as reader, AsarArchive(new_asar, mode="w") as writer:
+    with (
+        AsarArchive(asar, mode="r") as reader,
+        AsarArchive(new_asar, mode="w") as writer,
+    ):
         writer.pack_other_asar(reader)
 
     shutil.rmtree(dst, ignore_errors=True)
@@ -98,7 +103,10 @@ def test_pack_all():
     with AsarArchive(tmp_asar, mode="w") as writer:
         writer.pack_file(f3, src / "f1.txt")
         writer.pack_stream(f4, io.BytesIO(b"hello"))
-    with AsarArchive(tmp_asar, mode="r") as reader, AsarArchive(asar, mode="w") as writer:
+    with (
+        AsarArchive(tmp_asar, mode="r") as reader,
+        AsarArchive(asar, mode="w") as writer,
+    ):
         writer.pack(src)
         writer.pack_stream(f5, io.BytesIO(b"test"))
         writer.pack_other_asar(reader)
@@ -116,18 +124,26 @@ def test_read_asar_without_integrity_field():
     create_archive(src, broken_asar)
 
     with broken_asar.open("rb") as reader:
-        data_size, header_size, header_object_size, header_string_size = struct.unpack("<4I", reader.read(16))
+        data_size, header_size, header_object_size, header_string_size = struct.unpack(
+            "<4I", reader.read(16)
+        )
         header = json.loads(reader.read(header_string_size).decode("utf-8"))
         payload = reader.read()
 
     del header["files"]["f1.txt"]["integrity"]
-    header_json = json.dumps(header, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    header_json = json.dumps(
+        header, sort_keys=True, separators=(",", ":"), ensure_ascii=False
+    ).encode("utf-8")
     aligned_size = (len(header_json) + data_size - 1) & ~(data_size - 1)
     header_object_size = aligned_size + data_size
     header_size = header_object_size + data_size
 
     with broken_asar.open("wb") as writer:
-        writer.write(struct.pack("<4I", data_size, header_size, header_object_size, len(header_json)))
+        writer.write(
+            struct.pack(
+                "<4I", data_size, header_size, header_object_size, len(header_json)
+            )
+        )
         writer.write(header_json)
         writer.write(b"\0" * (aligned_size - len(header_json)))
         writer.write(payload)
@@ -147,7 +163,10 @@ def test_pack_other_asar_handles_zero_length_file():
 
         create_archive(source_dir, source_asar)
 
-        with AsarArchive(source_asar, mode="r") as reader, AsarArchive(copied_asar, mode="w") as writer:
+        with (
+            AsarArchive(source_asar, mode="r") as reader,
+            AsarArchive(copied_asar, mode="w") as writer,
+        ):
             writer.pack_other_asar(reader)
 
         with AsarArchive(copied_asar, mode="r") as archive:
@@ -160,12 +179,18 @@ def test_pack_other_asar_can_overwrite_existing_file():
     replacement_data = b"replaced via pack_other_asar workflow"
     new_asar = Path("./tests/testdata.overwrite.asar")
 
-    with AsarArchive(asar, mode="r") as reader, AsarArchive(new_asar, mode="w") as writer:
+    with (
+        AsarArchive(asar, mode="r") as reader,
+        AsarArchive(new_asar, mode="w") as writer,
+    ):
         writer.pack_other_asar(reader)
         writer.pack_stream(replaced, io.BytesIO(replacement_data))
 
     with AsarArchive(new_asar, mode="r") as archive:
         assert archive.read(replaced) == replacement_data
-        assert archive.read(Path("assets/icon.png")) == (src / "assets" / "icon.png").read_bytes()
+        assert (
+            archive.read(Path("assets/icon.png"))
+            == (src / "assets" / "icon.png").read_bytes()
+        )
         assert archive.read(Path("f2.exe")) == (src / "f2.exe").read_bytes()
         assert archive.read(Path("f1.txt")) != original_data

--- a/tests/test_asar.py
+++ b/tests/test_asar.py
@@ -15,9 +15,7 @@ def _cmp_dir(d1: Path, d2: Path):
     assert len(d1_files) == len(d2_files), f"dir {d1} and {d2} is different"
     for f1, f2 in zip(d1_files, d2_files):
         if f1.is_symlink() and f2.is_symlink():
-            return f1.resolve().relative_to(d1.resolve()) == f2.resolve().relative_to(
-                d2.resolve()
-            )
+            return f1.resolve().relative_to(d1.resolve()) == f2.resolve().relative_to(d2.resolve())
         if f1.is_dir() and f2.is_dir():
             return f1.name == f2.name
         if f1.is_file() and f2.is_file():
@@ -124,26 +122,20 @@ def test_read_asar_without_integrity_field():
     create_archive(src, broken_asar)
 
     with broken_asar.open("rb") as reader:
-        data_size, header_size, header_object_size, header_string_size = struct.unpack(
-            "<4I", reader.read(16)
-        )
+        data_size, header_size, header_object_size, header_string_size = struct.unpack("<4I", reader.read(16))
         header = json.loads(reader.read(header_string_size).decode("utf-8"))
         payload = reader.read()
 
     del header["files"]["f1.txt"]["integrity"]
-    header_json = json.dumps(
-        header, sort_keys=True, separators=(",", ":"), ensure_ascii=False
-    ).encode("utf-8")
+    header_json = json.dumps(header, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
+        "utf-8"
+    )
     aligned_size = (len(header_json) + data_size - 1) & ~(data_size - 1)
     header_object_size = aligned_size + data_size
     header_size = header_object_size + data_size
 
     with broken_asar.open("wb") as writer:
-        writer.write(
-            struct.pack(
-                "<4I", data_size, header_size, header_object_size, len(header_json)
-            )
-        )
+        writer.write(struct.pack("<4I", data_size, header_size, header_object_size, len(header_json)))
         writer.write(header_json)
         writer.write(b"\0" * (aligned_size - len(header_json)))
         writer.write(payload)
@@ -188,9 +180,6 @@ def test_pack_other_asar_can_overwrite_existing_file():
 
     with AsarArchive(new_asar, mode="r") as archive:
         assert archive.read(replaced) == replacement_data
-        assert (
-            archive.read(Path("assets/icon.png"))
-            == (src / "assets" / "icon.png").read_bytes()
-        )
+        assert archive.read(Path("assets/icon.png")) == (src / "assets" / "icon.png").read_bytes()
         assert archive.read(Path("f2.exe")) == (src / "f2.exe").read_bytes()
         assert archive.read(Path("f1.txt")) != original_data

--- a/tests/test_asar.py
+++ b/tests/test_asar.py
@@ -1,4 +1,6 @@
 import io
+import json
+import struct
 import shutil
 from pathlib import Path
 
@@ -95,3 +97,28 @@ def test_pack_all():
     assert (dst / f4).read_bytes() == b"hello"
     assert (dst / f5).read_bytes() == b"test"
     assert (dst / f6).read_bytes() == (src / "assets" / "icon.png").read_bytes()
+
+
+def test_read_asar_without_integrity_field():
+    broken_asar = Path("./tests/testdata.no-integrity.asar")
+    create_archive(src, broken_asar)
+
+    with broken_asar.open("rb") as reader:
+        data_size, header_size, header_object_size, header_string_size = struct.unpack("<4I", reader.read(16))
+        header = json.loads(reader.read(header_string_size).decode("utf-8"))
+        payload = reader.read()
+
+    del header["files"]["f1.txt"]["integrity"]
+    header_json = json.dumps(header, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+    aligned_size = (len(header_json) + data_size - 1) & ~(data_size - 1)
+    header_object_size = aligned_size + data_size
+    header_size = header_object_size + data_size
+
+    with broken_asar.open("wb") as writer:
+        writer.write(struct.pack("<4I", data_size, header_size, header_object_size, len(header_json)))
+        writer.write(header_json)
+        writer.write(b"\0" * (aligned_size - len(header_json)))
+        writer.write(payload)
+
+    with AsarArchive(broken_asar, mode="r") as archive:
+        assert archive.read(Path("f1.txt")) == (src / "f1.txt").read_bytes()

--- a/tests/test_asar.py
+++ b/tests/test_asar.py
@@ -76,6 +76,17 @@ def test_pack_file_and_stream():
         assert reader.read(added2_path) == added2_text
 
 
+def test_pack_stream_overwrites_existing_file_path_entry():
+    overwritten_path = Path("overwrite.txt")
+    replacement_data = b"stream wins over file"
+    with AsarArchive(asar, mode="w") as writer:
+        writer.pack_file(overwritten_path, src / "f1.txt")
+        writer.pack_stream(overwritten_path, io.BytesIO(replacement_data))
+
+    with AsarArchive(asar, mode="r") as reader:
+        assert reader.read(overwritten_path) == replacement_data
+
+
 def test_pack_all():
     tmp_asar = Path("./tests/testdata.tmp.asar")
     f3, f4, f5, f6 = (

--- a/tests/test_asar.py
+++ b/tests/test_asar.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from tempfile import TemporaryDirectory
 
 from asar import create_archive, extract_archive, AsarArchive
+from asar.asar import align_int
 
 
 def _cmp_dir(d1: Path, d2: Path):
@@ -124,13 +125,14 @@ def test_read_asar_without_integrity_field():
     with broken_asar.open("rb") as reader:
         data_size, header_size, header_object_size, header_string_size = struct.unpack("<4I", reader.read(16))
         header = json.loads(reader.read(header_string_size).decode("utf-8"))
+        reader.seek(8 + header_size)
         payload = reader.read()
 
     del header["files"]["f1.txt"]["integrity"]
     header_json = json.dumps(header, sort_keys=True, separators=(",", ":"), ensure_ascii=False).encode(
         "utf-8"
     )
-    aligned_size = (len(header_json) + data_size - 1) & ~(data_size - 1)
+    aligned_size = align_int(len(header_json), data_size)
     header_object_size = aligned_size + data_size
     header_size = header_object_size + data_size
 

--- a/tests/test_asar.py
+++ b/tests/test_asar.py
@@ -3,6 +3,7 @@ import json
 import struct
 import shutil
 from pathlib import Path
+from tempfile import TemporaryDirectory
 
 from asar import create_archive, extract_archive, AsarArchive
 
@@ -122,3 +123,21 @@ def test_read_asar_without_integrity_field():
 
     with AsarArchive(broken_asar, mode="r") as archive:
         assert archive.read(Path("f1.txt")) == (src / "f1.txt").read_bytes()
+
+
+def test_pack_other_asar_handles_zero_length_file():
+    with TemporaryDirectory() as temp_dir:
+        root = Path(temp_dir)
+        source_dir = root / "source"
+        source_dir.mkdir()
+        (source_dir / "empty.txt").write_bytes(b"")
+        source_asar = root / "source.asar"
+        copied_asar = root / "copied.asar"
+
+        create_archive(source_dir, source_asar)
+
+        with AsarArchive(source_asar, mode="r") as reader, AsarArchive(copied_asar, mode="w") as writer:
+            writer.pack_other_asar(reader)
+
+        with AsarArchive(copied_asar, mode="r") as archive:
+            assert archive.read(Path("empty.txt")) == b""

--- a/tests/test_asar.py
+++ b/tests/test_asar.py
@@ -152,3 +152,20 @@ def test_pack_other_asar_handles_zero_length_file():
 
         with AsarArchive(copied_asar, mode="r") as archive:
             assert archive.read(Path("empty.txt")) == b""
+
+
+def test_pack_other_asar_can_overwrite_existing_file():
+    replaced = Path("f1.txt")
+    original_data = (src / "f1.txt").read_bytes()
+    replacement_data = b"replaced via pack_other_asar workflow"
+    new_asar = Path("./tests/testdata.overwrite.asar")
+
+    with AsarArchive(asar, mode="r") as reader, AsarArchive(new_asar, mode="w") as writer:
+        writer.pack_other_asar(reader)
+        writer.pack_stream(replaced, io.BytesIO(replacement_data))
+
+    with AsarArchive(new_asar, mode="r") as archive:
+        assert archive.read(replaced) == replacement_data
+        assert archive.read(Path("assets/icon.png")) == (src / "assets" / "icon.png").read_bytes()
+        assert archive.read(Path("f2.exe")) == (src / "f2.exe").read_bytes()
+        assert archive.read(Path("f1.txt")) != original_data


### PR DESCRIPTION
The changes were driven by testing against a real production ASAR from an Electron app, where a few edge cases showed up that were not covered by the existing logic. I used OpenAI Codex to prepare this PR, and personally reviewed the changes.

## Problem

While using asar-py as the backend for a real ASAR patching tool, four issues showed up:

1. Some real ASAR headers omit integrity on file entries.
The reader assumed every file entry had integrity. That caused archive parsing to fail immediately on otherwise valid Electron ASARs.
Solution: Tolerate missing integrity in archive headers. Now `_parse_metadata()`  uses `child.get("integrity")` instead of requiring the field.

2. `LimitedReader.seek()` rejected seek-to-end on zero-length slices.
That broke zero-byte file handling and some copy paths that rely on resetting a bounded reader safely.
Solution: Allow bounded readers to seek to EOF. `LimitedReader.seek()` now accepts the end position. It also normalizes the final seek to an absolute seek, which is safer for wrapped readers.

3. Replacing a file stream after a file-path entry could leave stale state behind.
`Metadata.set_stream()` calculated integrity by consuming the stream, but did not rewind it. It also did not clear stale `file_path`. In overwrite workflows, that could produce incorrect or empty file output.
Solution: Reset stream/file state when replacing file entries. Now `Metadata.set_stream()` rewinds the stream after integrity calculation and clears `file_path`. Also, `Metadata.set_file()` clears stale `file_reader`.

4. `pack_other_asar()` was not robust for real archive copy/update use cases.
The original implementation reused source metadata and reader state directly. In practice, that was fragile for archive-to-archive rebuild flows and overwrite-after-copy scenarios. This created corrupted output and incorrect file contents in those workflows.
Solution: Make `pack_other_asar()` copy logical archive entries. Directories and links are recreated structurally. There was a small performance hit of about 30% with this change.


## Correctness
These fixes were validated in two ways. Added tests in this repo for each change, and tested against the real production ASAR on which I encountered those issues.